### PR TITLE
Allow compiliation without manual interference

### DIFF
--- a/CMakeLists.ros1.txt
+++ b/CMakeLists.ros1.txt
@@ -1,6 +1,3 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(imu_bno055)
-
 add_compile_options(-std=c++14 -li2c)
 
 find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs diagnostic_msgs)
@@ -21,4 +18,3 @@ install(TARGETS bno055_i2c_node
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-

--- a/CMakeLists.ros2.txt
+++ b/CMakeLists.ros2.txt
@@ -1,6 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-project(imu_bno055)
-
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -41,4 +38,3 @@ install(TARGETS bno055_i2c_node
 )
 
 ament_package()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+project(imu_bno055)
+
+find_package(ros_environment REQUIRED)
+
+set(ROS_VERSION $ENV{ROS_VERSION})
+
+if(${ROS_VERSION} EQUAL 1)
+  include(CMakeLists.ros1.txt)
+elseif(${ROS_VERSION} EQUAL 2)
+  include(CMakeLists.ros2.txt)
+endif()

--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ Install the prerequisites:
 sudo apt install libi2c-dev
 ```
 
-Copy or rename the appropriate CMakeLists file:
-
-```
-cp CMakeLists.ros1.txt CMakeLists.txt    # for ROS1
-cp CMakeLists.ros2.txt CMakeLists.txt    # for ROS2
-```
-
 and then you are ready to drop this package into a catkin (ROS1) or colcon (ROS2) workspace.
 
 ## How to run
@@ -59,4 +52,3 @@ The Raspberry Pi <=4 hardware I2C does not support clock stretching. You have a 
 ## NVIDIA Jetson platforms
 
 You may need to add your user to the i2c group, e.g. `sudo usermod -aG i2c nvidia`. It should just work after that.
-

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <license>BSD</license>
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
 
+  <build_depend>ros_environment</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>


### PR DESCRIPTION
Having manual steps in a readme kind of breaks deployment tooling.